### PR TITLE
Fix typos, dead code, random-pick bugs, and non-fatal report upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         cache: true
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: go test -v ./...
         
       - name: Build for Linux
-        run: go build -v -o astronomer-linux-amd64
+        run: go build -v -o staraudit-linux-amd64
         env:
           GOOS: linux
           GOARCH: amd64
@@ -33,7 +33,7 @@ jobs:
           GO111MODULE: on
       
       - name: Build for Windows
-        run: go build -v -o astronomer-windows-amd64.exe
+        run: go build -v -o staraudit-windows-amd64.exe
         env:
           GOOS: windows
           GOARCH: amd64
@@ -41,7 +41,7 @@ jobs:
           GO111MODULE: on
             
       - name: Build for MacOS (AMD64)
-        run: go build -v -o astronomer-darwin-amd64
+        run: go build -v -o staraudit-darwin-amd64
         env:
           GOOS: darwin
           GOARCH: amd64
@@ -49,7 +49,7 @@ jobs:
           GO111MODULE: on
       
       - name: Build for MacOS (ARM64)
-        run: go build -v -o astronomer-darwin-arm64
+        run: go build -v -o staraudit-darwin-arm64
         env:
           GOOS: darwin
           GOARCH: arm64
@@ -74,8 +74,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./astronomer-linux-amd64
-          asset_name: astronomer-linux-amd64
+          asset_path: ./staraudit-linux-amd64
+          asset_name: staraudit-linux-amd64
           asset_content_type: application/octet-stream
 
       - name: Upload Release Asset for Windows
@@ -85,8 +85,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./astronomer-windows-amd64.exe
-          asset_name: astronomer-windows-amd64.exe
+          asset_path: ./staraudit-windows-amd64.exe
+          asset_name: staraudit-windows-amd64.exe
           asset_content_type: application/octet-stream
       
       - name: Upload Release Asset for MacOS (AMD64)
@@ -96,8 +96,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./astronomer-darwin-amd64
-          asset_name: astronomer-darwin-amd64
+          asset_path: ./staraudit-darwin-amd64
+          asset_name: staraudit-darwin-amd64
           asset_content_type: application/octet-stream
 
       - name: Upload Release Asset for MacOS (ARM64)
@@ -107,6 +107,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./astronomer-darwin-arm64
-          asset_name: astronomer-darwin-arm64
+          asset_path: ./staraudit-darwin-arm64
+          asset_name: staraudit-darwin-arm64
           asset_content_type: application/octet-stream

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,51 +1,56 @@
-version: 2
+version: "2"
+
 run:
   timeout: 5m
 
 linters:
-  disable-all: true
+  default: none
   enable:
+    - bodyclose
     - errcheck
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-    - revive
+    - errorlint
+    - exhaustive
+    - forcetypeassert
+    - goconst
     - gocritic
     - gosec
-    - bodyclose
-    - noctx
-    - errorlint
-    - prealloc
-    - unparam
-    - nilerr
-    - forcetypeassert
+    - govet
+    - ineffassign
     - makezero
-    - exhaustive
-    - goconst
     - misspell
+    - nilerr
+    - noctx
+    - prealloc
+    - revive
+    - staticcheck
     - testifylint
-
-linters-settings:
-  revive:
+    - unparam
+    - unused
+  exclusions:
     rules:
-      - name: context-as-first-argument
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: if-return
-      - name: var-naming
-      - name: package-comments
-  exhaustive:
-    default-signifies-exhaustive: true
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  testifylint:
-    enable-all: true
+      # Repeated literals in test fixtures do not need to be constants.
+      - path: _test\.go
+        linters:
+          - goconst
+  settings:
+    revive:
+      rules:
+        - name: context-as-argument
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: if-return
+        - name: var-naming
+        - name: package-comments
+    exhaustive:
+      default-signifies-exhaustive: true
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    testifylint:
+      enable-all: true
 
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN apk --no-cache --no-progress add git ca-certificates && update-ca-certificat
 FROM scratch AS base
 
 COPY --from=base-image /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY dist/astronomer-linux-amd64 /astronomer
+COPY dist/staraudit-linux-amd64 /staraudit
 
-ENTRYPOINT ["/astronomer"]
+ENTRYPOINT ["/staraudit"]

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # Development Guidelines
 
-Specific instructions and best practices for the Astronomer project.
+Specific instructions and best practices for the StarAudit project.
 
 ## Core Principles
 
@@ -35,7 +35,7 @@ We use a `Makefile` as the single entry point for development tasks.
 | `test` | Run all unit tests. |
 | `lint` | Run `golangci-lint` (if installed). |
 | `format` | Run `go fmt` on the entire project. |
-| `build` | Compile the `astronomer` binary. |
+| `build` | Compile the `staraudit` binary. |
 | `docker` | Build the Docker image. |
 | `run` | Build and run the application locally (requires `REPO` env). |
 | `upgrade-deps` | Upgrade all dependencies to their latest versions. |
@@ -49,4 +49,4 @@ We use a `Makefile` as the single entry point for development tasks.
 ## Security
 
 - **GitHub Token**: Required via `GITHUB_TOKEN` environment variable.
-- **Private Key**: Can be provided via `ASTRONOMER_PRIVATE_KEY` environment variable. Falls back to an embedded key if not provided (not recommended for production).
+- **Private Key**: Can be provided via `STARAUDIT_PRIVATE_KEY` environment variable. Falls back to an embedded key if not provided (not recommended for production).

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# Makefile for Astronomer project
+# Makefile for StarAudit project
 
-BINARY_NAME=astronomer
-DOCKER_IMAGE=stn1slv/astronomer
+BINARY_NAME=staraudit
+DOCKER_IMAGE=stn1slv/staraudit
 
 .PHONY: all
 all: build test lint

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Astronomer
+# StarAudit
 
 <p align="center">
     <img width="300" src="img/logo.png"/>
@@ -7,7 +7,7 @@
 > [!NOTE]
 > This project is a continuation of [Ullaakut/astronomer](https://github.com/Ullaakut/astronomer), which was archived by the owner on Oct 12, 2020. This fork aims to maintain and modernize the tool for continued use.
 
-Astronomer is a high-performance tool that analyzes GitHub repository stargazers to compute the likelihood that they are real humans. Its primary goal is to **detect illegitimate GitHub stars from bot accounts**, which are often used to artificially inflate the perceived popularity of open-source projects.
+StarAudit is a high-performance tool that analyzes GitHub repository stargazers to compute the likelihood that they are real humans. Its primary goal is to **detect illegitimate GitHub stars from bot accounts**, which are often used to artificially inflate the perceived popularity of open-source projects.
 
 <p align="center">
     <img width="75%" src="img/astronomer.gif">
@@ -41,8 +41,8 @@ Trust is computed based on several factors:
 ### Installation
 
 ```bash
-git clone https://github.com/stn1slv/astronomer.git
-cd astronomer
+git clone https://github.com/stn1slv/staraudit.git
+cd staraudit
 make build
 ```
 
@@ -57,7 +57,7 @@ export GITHUB_TOKEN=your_token_here
 Run the scan:
 
 ```bash
-./astronomer ullaakut/astronomer
+./staraudit ullaakut/astronomer
 ```
 
 ## Arguments and Options
@@ -73,7 +73,7 @@ Run the scan:
 The project includes a `Makefile` to simplify common tasks:
 
 *   `make setup`: Bootstrap the project and download dependencies.
-*   `make build`: Compile the `astronomer` binary.
+*   `make build`: Compile the `staraudit` binary.
 *   `make test`: Run the full test suite.
 *   `make lint`: Run static analysis (requires `golangci-lint`).
 *   `make format`: Auto-format source code.
@@ -93,11 +93,11 @@ Repositories with high star counts often appear in GitHub Trending and newslette
 
 > _How accurate is this algorithm?_
 
-Astronomer provides an estimate. A low score might indicate a community of casual users or low precision due to a small sample size. It is meant as a diagnostic tool rather than an absolute verdict.
+StarAudit provides an estimate. A low score might indicate a community of casual users or low precision due to a small sample size. It is meant as a diagnostic tool rather than an absolute verdict.
 
 > _Why do results vary slightly between scans?_
 
-In fast mode, Astronomer scans the first 200 users and then takes random slices of the remaining stargazers. These random samples can lead to slight variations (1-3%) in the final score. Use the `--all` flag for a deterministic, comprehensive report.
+In fast mode, StarAudit scans the first 200 users and then takes random slices of the remaining stargazers. These random samples can lead to slight variations (1-3%) in the final score. Use the `--all` flag for a deterministic, comprehensive report.
 
 ## Thanks
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stn1slv/astronomer
+module github.com/stn1slv/staraudit
 
 go 1.25.0
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Package main is the entry point for the astronomer CLI tool.
+// Package main is the entry point for the staraudit CLI tool.
 package main
 
 import (
@@ -14,18 +14,18 @@ import (
 	"github.com/Ullaakut/disgo/style"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	astronomer_context "github.com/stn1slv/astronomer/pkg/context"
-	"github.com/stn1slv/astronomer/pkg/gql"
-	"github.com/stn1slv/astronomer/pkg/signature"
-	"github.com/stn1slv/astronomer/pkg/trust"
+	staraudit_context "github.com/stn1slv/staraudit/pkg/context"
+	"github.com/stn1slv/staraudit/pkg/gql"
+	"github.com/stn1slv/staraudit/pkg/signature"
+	"github.com/stn1slv/staraudit/pkg/trust"
 )
 
 func parseArguments() error {
-	viper.SetEnvPrefix("astronomer")
+	viper.SetEnvPrefix("staraudit")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	pflag.BoolP("verbose", "v", false, "Show extra logs (including comparative reports)")
-	pflag.BoolP("all", "a", false, "Force astronomer to scan every stargazer of the repository (overrides --stars)")
+	pflag.BoolP("all", "a", false, "Force staraudit to scan every stargazer of the repository (overrides --stars)")
 	pflag.UintP("stars", "s", 1000, "Maximum amount of stars to scan, if fast mode is enabled")
 	pflag.StringP("cachedir", "c", "./data", "Set the directory in which to store cache data")
 
@@ -75,7 +75,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	astronomerCtx := &astronomer_context.Context{
+	starauditCtx := &staraudit_context.Context{
 		RepoOwner:          repoInfo[0],
 		RepoName:           repoInfo[1],
 		GithubToken:        token,
@@ -85,16 +85,16 @@ func main() {
 		Verbose:            viper.GetBool("verbose"),
 	}
 
-	if err := detectFakeStars(ctx, astronomerCtx); err != nil {
+	if err := detectFakeStars(ctx, starauditCtx); err != nil {
 		disgo.Errorln(style.Failure(style.SymbolCross, " ", err))
 		os.Exit(1)
 	}
 }
 
-func detectFakeStars(ctx context.Context, astronomerCtx *astronomer_context.Context) error {
-	disgo.Infof("Beginning fetching process for repository %s/%s\n", astronomerCtx.RepoOwner, astronomerCtx.RepoName)
+func detectFakeStars(ctx context.Context, starauditCtx *staraudit_context.Context) error {
+	disgo.Infof("Beginning fetching process for repository %s/%s\n", starauditCtx.RepoOwner, starauditCtx.RepoName)
 
-	cursors, totalUsers, err := gql.FetchStargazers(ctx, astronomerCtx)
+	cursors, totalUsers, err := gql.FetchStargazers(ctx, starauditCtx)
 	if err != nil {
 		return fmt.Errorf("failed to query stargazer data: %w", err)
 	}
@@ -105,34 +105,34 @@ func detectFakeStars(ctx context.Context, astronomerCtx *astronomer_context.Cont
 
 	// For now, we only fetch contributions since 2013. It will be configurable later on
 	// once the algorithm is more accurate and more data has been fetched.
-	if !astronomerCtx.ScanAll && totalUsers > astronomerCtx.Stars {
-		disgo.Infof("Fetching contributions for %d users up to year %d\n", astronomerCtx.Stars, 2013)
+	if !starauditCtx.ScanAll && totalUsers > starauditCtx.Stars {
+		disgo.Infof("Fetching contributions for %d users up to year %d\n", starauditCtx.Stars, 2013)
 	} else {
 		disgo.Infof("Fetching contributions for %d users up to year %d\n", totalUsers, 2013)
 	}
 
-	users, err := gql.FetchContributions(ctx, astronomerCtx, cursors, 2013)
+	users, err := gql.FetchContributions(ctx, starauditCtx, cursors, 2013)
 	if err != nil {
 		return fmt.Errorf("failed to query stargazer data: %w", err)
 	}
 
-	report, err := trust.Compute(ctx, astronomerCtx, users)
+	report, err := trust.Compute(ctx, starauditCtx, users)
 	if err != nil {
 		return fmt.Errorf("unable to compute trust report: %w", err)
 	}
 
 	trust.Render(report, true)
 
-	// Failing to send the report to the astronomer server is not fatal:
+	// Failing to send the report to the staraudit server is not fatal:
 	// the report has already been computed and rendered locally.
-	err = signature.SendReport(ctx, astronomerCtx, report)
+	err = signature.SendReport(ctx, starauditCtx, report)
 	if err != nil {
-		disgo.Errorln(style.Important("Unable to send trust report to the astronomer server: ", err))
+		disgo.Errorln(style.Important("Unable to send trust report to the staraudit server: ", err))
 	}
 
 	disgo.Infof("\n%s Analysis successful. %d users computed.\n", style.Success(style.SymbolCheck), len(users))
 
-	badgeEndpoint := url.QueryEscape(fmt.Sprintf("https://astronomer.ullaakut.eu/shields?owner=%s&name=%s", astronomerCtx.RepoOwner, astronomerCtx.RepoName))
+	badgeEndpoint := url.QueryEscape(fmt.Sprintf("https://astronomer.ullaakut.eu/shields?owner=%s&name=%s", starauditCtx.RepoOwner, starauditCtx.RepoName))
 
 	disgo.Infof("GitHub badge available at https://img.shields.io/endpoint.svg?url=%s\n", badgeEndpoint)
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -48,10 +49,18 @@ func parseArguments() error {
 }
 
 func main() {
+	if err := run(); err != nil {
+		disgo.Errorln(style.Failure(style.SymbolCross, " ", err))
+		os.Exit(1)
+	}
+}
+
+// run executes the scan. It is separated from main so that deferred
+// cleanups run before the process exits with an error code.
+func run() error {
 	err := parseArguments()
 	if err != nil {
-		disgo.Errorln(style.Failure(style.SymbolCross, err))
-		os.Exit(1)
+		return err
 	}
 
 	disgo.SetTerminalOptions(disgo.WithColors(true), disgo.WithDebug(viper.GetBool("verbose")))
@@ -65,14 +74,12 @@ func main() {
 	// Split repository into repo owner & repo name.
 	repoInfo := strings.Split(repository, "/")
 	if len(repoInfo) != 2 {
-		disgo.Errorln(style.Failure(style.SymbolCross, " invalid repository %q: should be of the form \"repoOwner/repoName\"", repository))
-		os.Exit(1)
+		return fmt.Errorf("invalid repository %q: should be of the form \"repoOwner/repoName\"", repository)
 	}
 
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
-		disgo.Errorln(style.Failure(style.SymbolCross, " missing github access token. Please set one in your GITHUB_TOKEN environment variable, with \"repo\" rights."))
-		os.Exit(1)
+		return errors.New("missing github access token. Please set one in your GITHUB_TOKEN environment variable, with \"repo\" rights")
 	}
 
 	starauditCtx := &staraudit_context.Context{
@@ -85,10 +92,7 @@ func main() {
 		Verbose:            viper.GetBool("verbose"),
 	}
 
-	if err := detectFakeStars(ctx, starauditCtx); err != nil {
-		disgo.Errorln(style.Failure(style.SymbolCross, " ", err))
-		os.Exit(1)
-	}
+	return detectFakeStars(ctx, starauditCtx)
 }
 
 func detectFakeStars(ctx context.Context, starauditCtx *staraudit_context.Context) error {

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ func parseArguments() error {
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	pflag.BoolP("verbose", "v", false, "Show extra logs (including comparative reports)")
-	pflag.BoolP("all", "a", false, "Force astronomer to scall every stargazer of the repository (overrides --stars)")
-	pflag.UintP("stars", "s", 1000, "Maxmimum amount of stars to scan, if fast mode is enabled")
+	pflag.BoolP("all", "a", false, "Force astronomer to scan every stargazer of the repository (overrides --stars)")
+	pflag.UintP("stars", "s", 1000, "Maximum amount of stars to scan, if fast mode is enabled")
 	pflag.StringP("cachedir", "c", "./data", "Set the directory in which to store cache data")
 
 	viper.AutomaticEnv()
@@ -38,7 +38,7 @@ func parseArguments() error {
 		return err
 	}
 
-	if viper.GetBool("help") || len(pflag.Args()) == 0 {
+	if len(pflag.Args()) == 0 {
 		disgo.Infoln("Missing required repository argument")
 		pflag.Usage()
 		os.Exit(0)
@@ -123,9 +123,11 @@ func detectFakeStars(ctx context.Context, astronomerCtx *astronomer_context.Cont
 
 	trust.Render(report, true)
 
+	// Failing to send the report to the astronomer server is not fatal:
+	// the report has already been computed and rendered locally.
 	err = signature.SendReport(ctx, astronomerCtx, report)
 	if err != nil {
-		return fmt.Errorf("unable to send trust report: %w", err)
+		disgo.Errorln(style.Important("Unable to send trust report to the astronomer server: ", err))
 	}
 
 	disgo.Infof("\n%s Analysis successful. %d users computed.\n", style.Success(style.SymbolCheck), len(users))

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,14 +1,14 @@
-// Package context provides a shared context for the astronomer application.
+// Package context provides a shared context for the staraudit application.
 package context
 
-// Context represents the context of an Astronomer scan.
+// Context represents the context of an StarAudit scan.
 type Context struct {
 	RepoOwner          string
 	RepoName           string
 	GithubToken        string
 	CacheDirectoryPath string
 
-	// ScanAll makes astronomer scan every stargazer
+	// ScanAll makes staraudit scan every stargazer
 	// when set to true.
 	ScanAll bool
 

--- a/pkg/gql/cache.go
+++ b/pkg/gql/cache.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/kennygrant/sanitize"
-	"github.com/stn1slv/astronomer/pkg/context"
+	"github.com/stn1slv/staraudit/pkg/context"
 )
 
 // getCache searches the cache directory for a file matching the

--- a/pkg/gql/cache.go
+++ b/pkg/gql/cache.go
@@ -63,12 +63,6 @@ func putCache(ctx *context.Context, req *http.Request, pagination string, body [
 		return fmt.Errorf("unable to write response in cache file: %w", err)
 	}
 
-	resp, err := readCachedResponse(filename)
-	if err != nil {
-		return err
-	}
-	_ = resp.Body.Close()
-
 	return nil
 }
 
@@ -79,7 +73,7 @@ func cacheEntryFilename(ctx *context.Context, url string) string {
 	return filepath.Join(ctx.CacheDirectoryPath, ctx.RepoOwner, ctx.RepoName, sanitize.BaseName(newURL))
 }
 
-// listilePagination generates the pagination to append to the cache file names
+// listFilePagination generates the pagination to append to the cache file names
 // for stargazer lists.
 func listFilePagination(cursor string) string {
 	if cursor == "" {

--- a/pkg/gql/cache_test.go
+++ b/pkg/gql/cache_test.go
@@ -3,19 +3,19 @@ package gql
 import (
 	"testing"
 
-	"github.com/stn1slv/astronomer/pkg/context"
+	"github.com/stn1slv/staraudit/pkg/context"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCacheEntryFilename(t *testing.T) {
 	ctx := &context.Context{
 		RepoOwner:          "ullaakut",
-		RepoName:           "astronomer",
+		RepoName:           "staraudit",
 		GithubToken:        "fakeToken",
 		CacheDirectoryPath: "./data",
 	}
 
 	sanitizedFilename := cacheEntryFilename(ctx, "https://fakeapi.com/graphql?access_token=fakeToken-1-2019")
 
-	assert.Equal(t, "data/ullaakut/astronomer/https-fakeapi-com-graphql-1-2019", sanitizedFilename)
+	assert.Equal(t, "data/ullaakut/staraudit/https-fakeapi-com-graphql-1-2019", sanitizedFilename)
 }

--- a/pkg/gql/fetch.go
+++ b/pkg/gql/fetch.go
@@ -182,7 +182,7 @@ func FetchStargazers(ctx stdcontext.Context, astronomerCtx *context.Context) (cu
 
 // FetchContributions fetches the contribution data of a list of stargazers.
 // astronomerCtx contains the scanned context of the astronomer command.
-// untilYear is the year until which to scan for contribuitons.
+// untilYear is the year until which to scan for contributions.
 func FetchContributions(ctx stdcontext.Context, astronomerCtx *context.Context, cursors []string, untilYear int) ([]User, error) {
 	var (
 		users []User
@@ -460,20 +460,16 @@ func getCursors(astronomerCtx *context.Context, sg []stargazers, totalUsers uint
 		disgo.Infof("Selecting all %d remaining stargazers\n", totalUsers-200)
 		selectedCursors = append(selectedCursors, cursors[:len(cursors)-beginCursorAmount]...)
 	} else {
-		// endCursorAmount is the amount of cursors to fetch to get the random users.
-		endCursorAmount := totalCursorAmount - beginCursorAmount
-		disgo.Infof("Selecting %d random stargazers out of %d\n", (endCursorAmount-1)*contribPagination, totalUsers)
+		// endCursorAmount is the amount of cursors to fetch to get the random
+		// users. One page is subtracted because the first page of stargazers
+		// is always fetched without a cursor.
+		endCursorAmount := totalCursorAmount - beginCursorAmount - 1
+		disgo.Infof("Selecting %d random stargazers out of %d\n", endCursorAmount*contribPagination, totalUsers)
 
-		selectedCursors = pickRandomStringsExcept(cursors, selectedCursors, uint(endCursorAmount)) // #nosec G115
+		selectedCursors = pickRandomExcept(cursors, selectedCursors, uint(endCursorAmount)) // #nosec G115
 	}
 
 	return selectedCursors
-}
-
-// Pick random strings picks ${amount} random strings from the
-// given slice of strings, except those that were already picked.
-func pickRandomStringsExcept(s []string, picked []string, amount uint) []string {
-	return pickRandomExcept(s, picked, amount)
 }
 
 // pickRandomExcept picks `amount` random elements from the
@@ -482,9 +478,9 @@ func pickRandomExcept[T comparable](s []T, picked []T, amount uint) []T {
 	// Make the random non-deterministic.
 	random := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano()))) // #nosec G404
 
-	for i := uint(1); i < amount; i++ {
+	for remaining := amount; remaining > 0; {
 		// Pick an element.
-		newPick := s[random.IntN(len(s)-1)]
+		newPick := s[random.IntN(len(s))]
 
 		// Check if it has already been selected.
 		var found bool
@@ -495,13 +491,13 @@ func pickRandomExcept[T comparable](s []T, picked []T, amount uint) []T {
 			}
 		}
 
-		// Regenerate another one if this index has already been selected.
+		// Regenerate another one if this element has already been selected.
 		if found {
-			i--
 			continue
 		}
 
 		picked = append(picked, newPick)
+		remaining--
 	}
 
 	return picked

--- a/pkg/gql/fetch.go
+++ b/pkg/gql/fetch.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Ullaakut/disgo"
 	"github.com/Ullaakut/disgo/style"
 	"github.com/cenkalti/backoff/v3"
-	"github.com/stn1slv/astronomer/pkg/context"
+	"github.com/stn1slv/staraudit/pkg/context"
 	"github.com/vbauerster/mpb/v4"
 	"github.com/vbauerster/mpb/v4/decor"
 	"golang.org/x/sync/errgroup"
@@ -31,7 +31,7 @@ var (
 	// blacklistedUsers contains the list of users that can't be
 	// fetched from the GitHub API. When one of these users is found
 	// in a list request, he must be skipped when fetching user contributions
-	// or astronomer will be stuck due to constant API timeouts.
+	// or staraudit will be stuck due to constant API timeouts.
 	blacklistedUsers = []string{
 		// "jstrachan", // has been fixed.
 	}
@@ -39,7 +39,7 @@ var (
 
 // FetchStargazers fetches the list of cursors to iterate upon to
 // fetch stargazer contributions.
-func FetchStargazers(ctx stdcontext.Context, astronomerCtx *context.Context) (cursors []string, totalUsers uint, err error) {
+func FetchStargazers(ctx stdcontext.Context, starauditCtx *context.Context) (cursors []string, totalUsers uint, err error) {
 	var (
 		stargazers     []stargazers
 		lastCursor     string
@@ -47,18 +47,18 @@ func FetchStargazers(ctx stdcontext.Context, astronomerCtx *context.Context) (cu
 		rateLimitSleep time.Duration
 	)
 
-	if astronomerCtx.Stars < uint(contribPagination) {
+	if starauditCtx.Stars < uint(contribPagination) {
 		return nil, 0, fmt.Errorf("unable to compute less stars than the amount fetched per page. Please set stars to at least %d", contribPagination)
 	}
 
 	// Round amount of stars to get according to pagination.
-	if astronomerCtx.Stars%contribPagination != 0 {
-		astronomerCtx.Stars -= astronomerCtx.Stars % contribPagination
-		disgo.Errorln(style.Failure("Rounding amount of stars to fetch to ", astronomerCtx.Stars, " in order to match pagination"))
+	if starauditCtx.Stars%contribPagination != 0 {
+		starauditCtx.Stars -= starauditCtx.Stars % contribPagination
+		disgo.Errorln(style.Failure("Rounding amount of stars to fetch to ", starauditCtx.Stars, " in order to match pagination"))
 	}
 
 	// Inject constants in request body.
-	requestBody := buildRequestBody(astronomerCtx, fetchUsersRequest, listPagination)
+	requestBody := buildRequestBody(starauditCtx, fetchUsersRequest, listPagination)
 	client := &http.Client{Timeout: defaultTimeout}
 
 	disgo.StartStep("Pre-fetching all stargazers")
@@ -84,11 +84,11 @@ func FetchStargazers(ctx stdcontext.Context, astronomerCtx *context.Context) (cu
 			return nil, 0, disgo.FailStepf("unable to prepare request: %v", err)
 		}
 
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", astronomerCtx.GithubToken))
-		req.Header.Set("User-Agent", "Astronomer")
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", starauditCtx.GithubToken))
+		req.Header.Set("User-Agent", "StarAudit")
 
 		// in the cache directory.
-		resp, err := getCache(astronomerCtx, req, listFilePagination(lastCursor)) // nolint:bodyclose
+		resp, err := getCache(starauditCtx, req, listFilePagination(lastCursor)) // nolint:bodyclose
 		if err != nil {
 			return nil, 0, disgo.FailStepf("unable to get cached file: %v", err)
 		}
@@ -153,7 +153,7 @@ func FetchStargazers(ctx stdcontext.Context, astronomerCtx *context.Context) (cu
 
 		// Since we arrived here, we got a successful response, so we store it
 		// in the cache directory.
-		err = putCache(astronomerCtx, req, listFilePagination(lastCursor), responseBody)
+		err = putCache(starauditCtx, req, listFilePagination(lastCursor), responseBody)
 		if err != nil {
 			return nil, 0, disgo.FailStepf("unable to write user contribution data to cache: %v", err)
 		}
@@ -175,21 +175,21 @@ func FetchStargazers(ctx stdcontext.Context, astronomerCtx *context.Context) (cu
 		}
 	}
 
-	cursors = getCursors(astronomerCtx, stargazers, totalUsers)
+	cursors = getCursors(starauditCtx, stargazers, totalUsers)
 
 	return cursors, totalUsers, nil
 }
 
 // FetchContributions fetches the contribution data of a list of stargazers.
-// astronomerCtx contains the scanned context of the astronomer command.
+// starauditCtx contains the scanned context of the staraudit command.
 // untilYear is the year until which to scan for contributions.
-func FetchContributions(ctx stdcontext.Context, astronomerCtx *context.Context, cursors []string, untilYear int) ([]User, error) {
+func FetchContributions(ctx stdcontext.Context, starauditCtx *context.Context, cursors []string, untilYear int) ([]User, error) {
 	var (
 		users []User
 		mu    sync.Mutex
 	)
 
-	requestBody := buildRequestBody(astronomerCtx, fetchContributionsRequest, contribPagination)
+	requestBody := buildRequestBody(starauditCtx, fetchContributionsRequest, contribPagination)
 	client := &http.Client{Timeout: defaultTimeout}
 
 	progress, bar := setupProgressBar(len(cursors))
@@ -197,7 +197,7 @@ func FetchContributions(ctx stdcontext.Context, astronomerCtx *context.Context, 
 
 	// If we are scanning only a portion of stargazers, the
 	// scan does not start with a page without a cursor.
-	isReverseOrder := uint(len(cursors)) > astronomerCtx.Stars/contribPagination
+	isReverseOrder := uint(len(cursors)) > starauditCtx.Stars/contribPagination
 
 	totalPages := len(cursors)
 
@@ -222,7 +222,7 @@ func FetchContributions(ctx stdcontext.Context, astronomerCtx *context.Context, 
 			for i := 0; currentYear-i > untilYear-1; i++ {
 				yearToFetch := currentYear - i
 
-				err := fetchYearlyContributions(gCtx, astronomerCtx, client, requestBody, currentCursor, yearToFetch, untilYear, &users, &mu, bar)
+				err := fetchYearlyContributions(gCtx, starauditCtx, client, requestBody, currentCursor, yearToFetch, untilYear, &users, &mu, bar)
 				if err != nil {
 					return err
 				}
@@ -242,7 +242,7 @@ func FetchContributions(ctx stdcontext.Context, astronomerCtx *context.Context, 
 
 func fetchYearlyContributions(
 	ctx stdcontext.Context,
-	astronomerCtx *context.Context,
+	starauditCtx *context.Context,
 	client *http.Client,
 	requestBody string,
 	currentCursor string,
@@ -280,11 +280,11 @@ func fetchYearlyContributions(
 	}
 
 	// Inject GitHub token for API authorization.
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", astronomerCtx.GithubToken))
-	req.Header.Set("User-Agent", "Astronomer")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", starauditCtx.GithubToken))
+	req.Header.Set("User-Agent", "StarAudit")
 
 	// Try to get a cached response to this request.
-	resp, err := getCache(astronomerCtx, req, contribFilePagination(currentCursor, currentYear)) // nolint:bodyclose
+	resp, err := getCache(starauditCtx, req, contribFilePagination(currentCursor, currentYear)) // nolint:bodyclose
 	if err != nil {
 		return fmt.Errorf("unable to get cached file: %w", err)
 	}
@@ -370,7 +370,7 @@ func fetchYearlyContributions(
 	// If file was fetched, write it in the cache. If we already got it from the cache,
 	// no need to rewrite it.
 	if !cachedFileFound {
-		err = putCache(astronomerCtx, req, contribFilePagination(currentCursor, currentYear), responseBody)
+		err = putCache(starauditCtx, req, contribFilePagination(currentCursor, currentYear), responseBody)
 		if err != nil {
 			mu.Lock()
 			usersSoFar := len(*users)
@@ -385,10 +385,10 @@ func fetchYearlyContributions(
 	return nil
 }
 
-func buildRequestBody(astronomerCtx *context.Context, baseRequest string, pagination int) string {
+func buildRequestBody(starauditCtx *context.Context, baseRequest string, pagination int) string {
 	// Inject constant values into request body.
-	requestBody := strings.Replace(baseRequest, "$repoOwner", astronomerCtx.RepoOwner, 1)
-	requestBody = strings.Replace(requestBody, "$repoName", astronomerCtx.RepoName, 1)
+	requestBody := strings.Replace(baseRequest, "$repoOwner", starauditCtx.RepoOwner, 1)
+	requestBody = strings.Replace(requestBody, "$repoName", starauditCtx.RepoName, 1)
 	requestBody = strings.Replace(requestBody, "$pagination", fmt.Sprint(pagination), 1)
 
 	// Remove all `\n` so that it's valid JSON. Remove all spaces.
@@ -402,7 +402,7 @@ func buildRequestBody(astronomerCtx *context.Context, baseRequest string, pagina
 // Return the appropriate cursors to be used by the fetchContributions function
 // according to the value of ${contribPagination}. Also makes sure not to include
 // any page of users containing blacklisted individuals.
-func getCursors(astronomerCtx *context.Context, sg []stargazers, totalUsers uint) []string {
+func getCursors(starauditCtx *context.Context, sg []stargazers, totalUsers uint) []string {
 	var (
 		skip      bool
 		iteration uint
@@ -448,7 +448,7 @@ func getCursors(astronomerCtx *context.Context, sg []stargazers, totalUsers uint
 	var selectedCursors []string
 
 	// totalCursorAmount is the total amount of cursors to fetch.
-	totalCursorAmount := int(astronomerCtx.Stars) / contribPagination // #nosec G115
+	totalCursorAmount := int(starauditCtx.Stars) / contribPagination // #nosec G115
 
 	// beginCursorAmount is the amount of cursors to fetch for the 200 first users.
 	disgo.Infof("Selecting 200 first stargazers out of %d\n", totalUsers)
@@ -456,7 +456,7 @@ func getCursors(astronomerCtx *context.Context, sg []stargazers, totalUsers uint
 
 	selectedCursors = append(selectedCursors, cursors[len(cursors)-beginCursorAmount-1:len(cursors)-1]...)
 
-	if astronomerCtx.ScanAll || totalUsers < astronomerCtx.Stars {
+	if starauditCtx.ScanAll || totalUsers < starauditCtx.Stars {
 		disgo.Infof("Selecting all %d remaining stargazers\n", totalUsers-200)
 		selectedCursors = append(selectedCursors, cursors[:len(cursors)-beginCursorAmount]...)
 	} else {

--- a/pkg/gql/fetch_test.go
+++ b/pkg/gql/fetch_test.go
@@ -3,7 +3,7 @@ package gql
 import (
 	"testing"
 
-	"github.com/stn1slv/astronomer/pkg/context"
+	"github.com/stn1slv/staraudit/pkg/context"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,12 +37,12 @@ func TestBuildRequestBody(t *testing.T) {
 	for description, test := range tests {
 		t.Run(description, func(t *testing.T) {
 			t.Parallel()
-			astronomerCtx := &context.Context{
+			starauditCtx := &context.Context{
 				RepoOwner: test.repoOwner,
 				RepoName:  test.repoName,
 			}
 
-			requestBody := buildRequestBody(astronomerCtx, test.baseRequest, test.pagination)
+			requestBody := buildRequestBody(starauditCtx, test.baseRequest, test.pagination)
 
 			assert.Equal(t, test.expectedBody, requestBody)
 		})
@@ -143,12 +143,12 @@ func TestGetCursors(t *testing.T) {
 	for description, test := range tests {
 		t.Run(description, func(t *testing.T) {
 			t.Parallel()
-			astronomerCtx := &context.Context{
+			starauditCtx := &context.Context{
 				ScanAll: test.scanAll,
 				Stars:   test.starLimit,
 			}
 
-			cursors := getCursors(astronomerCtx, test.stargazers, test.totalUsers)
+			cursors := getCursors(starauditCtx, test.stargazers, test.totalUsers)
 
 			assert.Equal(t, test.expectedCursors, cursors)
 		})

--- a/pkg/signature/check.go
+++ b/pkg/signature/check.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Check verifies whether a report has been signed
-// with a legitimate version of Astronomer.
+// with a legitimate version of StarAudit.
 func Check(report *SignedReport) error {
 	data, err := json.Marshal(report.Report)
 	if err != nil {

--- a/pkg/signature/send.go
+++ b/pkg/signature/send.go
@@ -15,12 +15,12 @@ import (
 	"os"
 
 	"github.com/Ullaakut/disgo"
-	astronomer_context "github.com/stn1slv/astronomer/pkg/context"
-	"github.com/stn1slv/astronomer/pkg/trust"
+	staraudit_context "github.com/stn1slv/staraudit/pkg/context"
+	"github.com/stn1slv/staraudit/pkg/trust"
 )
 
 // SignedReport represents a report that has been signed
-// by a legitimate version of Astronomer.
+// by a legitimate version of StarAudit.
 type SignedReport struct {
 	*trust.Report
 
@@ -31,7 +31,7 @@ type SignedReport struct {
 }
 
 // SendReport signs a report and sends it to Astrolab.
-func SendReport(ctx stdcontext.Context, astronomerCtx *astronomer_context.Context, report *trust.Report) error {
+func SendReport(ctx stdcontext.Context, starauditCtx *staraudit_context.Context, report *trust.Report) error {
 	signature, err := signReport(report)
 	if err != nil {
 		return err
@@ -39,8 +39,8 @@ func SendReport(ctx stdcontext.Context, astronomerCtx *astronomer_context.Contex
 
 	return sendReport(ctx, SignedReport{
 		Report:          report,
-		RepositoryOwner: astronomerCtx.RepoOwner,
-		RepositoryName:  astronomerCtx.RepoName,
+		RepositoryOwner: starauditCtx.RepoOwner,
+		RepositoryName:  starauditCtx.RepoName,
 		Signature:       signature,
 	})
 }
@@ -53,7 +53,7 @@ func signReport(report *trust.Report) ([]byte, error) {
 
 	hashedReport := sha512.Sum512(data)
 
-	pemKey := os.Getenv("ASTRONOMER_PRIVATE_KEY")
+	pemKey := os.Getenv("STARAUDIT_PRIVATE_KEY")
 	if pemKey == "" {
 		pemKey = privateKeyPemData
 	}
@@ -84,22 +84,22 @@ func sendReport(ctx stdcontext.Context, report SignedReport) error {
 
 	req, err := http.NewRequestWithContext(ctx, "POST", "https://astronomer.ullaakut.eu", bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("unable to prepare request to astronomer server: %w", err)
+		return fmt.Errorf("unable to prepare request to staraudit server: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	response, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("unable to send signed report to astronomer server: %w", err)
+		return fmt.Errorf("unable to send signed report to staraudit server: %w", err)
 	}
 	defer func() { _ = response.Body.Close() }()
 
 	if response.StatusCode != 201 {
-		return fmt.Errorf("astronomer server did not trust this report: %v", response.Status)
+		return fmt.Errorf("staraudit server did not trust this report: %v", response.Status)
 	}
 
-	disgo.Debugln("Signed report successfully sent to astronomer server, thanks for your contribution!")
+	disgo.Debugln("Signed report successfully sent to staraudit server, thanks for your contribution!")
 
 	return nil
 }

--- a/pkg/trust/compute.go
+++ b/pkg/trust/compute.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stn1slv/astronomer/pkg/gql"
 )
 
-// Factor represents one of the trust factors used to compte
+// Factor represents one of the trust factors used to compute
 // the trust score for a repository.
 type Factor struct {
 	// The raw value of this factor.

--- a/pkg/trust/compute.go
+++ b/pkg/trust/compute.go
@@ -10,8 +10,8 @@ import (
 	"github.com/Ullaakut/disgo"
 	"github.com/Ullaakut/disgo/style"
 	"github.com/montanaflynn/stats"
-	astronomer_context "github.com/stn1slv/astronomer/pkg/context"
-	"github.com/stn1slv/astronomer/pkg/gql"
+	staraudit_context "github.com/stn1slv/staraudit/pkg/context"
+	"github.com/stn1slv/staraudit/pkg/gql"
 )
 
 // Factor represents one of the trust factors used to compute
@@ -43,7 +43,7 @@ type Report struct {
 }
 
 // Compute computes all trust factors for the stargazers of a repository.
-func Compute(_ context.Context, _ *astronomer_context.Context, users []gql.User) (*Report, error) {
+func Compute(_ context.Context, _ *staraudit_context.Context, users []gql.User) (*Report, error) {
 	trustData := make(map[FactorName][]float64)
 	now := time.Now().Year()
 

--- a/pkg/trust/factors.go
+++ b/pkg/trust/factors.go
@@ -1,6 +1,6 @@
 package trust
 
-// All of the factors taken into account by Astronomer
+// All of the factors taken into account by StarAudit
 // and shown in the report.
 const (
 	PrivateContributionFactor  FactorName = "Private contributions"

--- a/pkg/trust/render_test.go
+++ b/pkg/trust/render_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/Ullaakut/disgo"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrintTrustFactor(t *testing.T) {


### PR DESCRIPTION
- Fix typos in CLI help text and comments (scan, Maximum, compute,
  contributions, listFilePagination)
- Remove dead check of undefined 'help' flag in parseArguments
- Remove pointless re-read of the cache file in putCache
- Remove no-op pickRandomStringsExcept wrapper
- pickRandomExcept: pick exactly 'amount' elements and allow the last
  element of the slice to be selected; move the first-page accounting
  to the call site where it is explained
- Treat a failure to send the signed report to the astronomer server
  as a warning instead of failing the whole scan, since the report is
  already computed and rendered locally

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LBfFoxBFtsQAgFmdy7ZQn8